### PR TITLE
docs: update documentation for llama.cpp-omni

### DIFF
--- a/deployment/llama.cpp-omni/minicpmo_4_5_llamacpp_omni.md
+++ b/deployment/llama.cpp-omni/minicpmo_4_5_llamacpp_omni.md
@@ -1,0 +1,469 @@
+# MiniCPM-o 4.5 · llama.cpp-omni Usage Guide
+
+This document describes how to run multimodal inference for MiniCPM-o 4.5 on top of this repository (**llama.cpp-omni**), covering three main usages:
+
+1. **Command-line CLI** (`tools/omni/omni-cli.cpp` → `llama-omni-cli`)
+2. **Test programs** (`tools/omni/test/` → simplex audio / simplex omni / duplex)
+3. **Omni server** (`tools/server/ws_handler.cpp` etc. → `llama-omni-server`)
+
+Plus the accompanying **Demo** (HuggingFace Space and the locally-deployable MiniCPM-o-Demo).
+
+> The examples in this document are verified on Linux + NVIDIA CUDA (RTX 4090); on macOS replace `CUDA` with `Metal`, the commands are the same.
+
+---
+
+## Table of Contents
+
+- [Part 1: llama.cpp-omni (this repository)](#part-1-llamacpp-omni-this-repository)
+  - [1. Environment & Build](#1-environment--build)
+  - [2. Download the Model](#2-download-the-model)
+  - [3. Usage 1: CLI (`llama-omni-cli`)](#3-usage-1-cli-llama-omni-cli)
+  - [4. Usage 2: Test Programs (`tools/omni/test/`)](#4-usage-2-test-programs-toolsomnitest)
+  - [5. Usage 3: Omni Server (`llama-omni-server`)](#5-usage-3-omni-server-llama-omni-server)
+- [Part 2: Demo](#part-2-demo)
+
+---
+
+# Part 1: llama.cpp-omni (this repository)
+
+llama.cpp-omni splits MiniCPM-o 4.5 into several independent GGUF modules that cooperate during inference:
+
+| Module | Role |
+| --- | --- |
+| **LLM** | Main language model (Qwen3-8B); receives vision/audio embeddings and generates text tokens |
+| **VPM** (vision) | Vision encoder (SigLip2 + Resampler); encodes images into the LLM hidden space |
+| **APM** (audio) | Audio encoder (Whisper); encodes 16 kHz audio into the LLM hidden space |
+| **TTS** | Text-to-speech model; turns LLM hidden states into audio tokens |
+| **Token2Wav** | Vocoder (Flow Matching + HiFiGAN); synthesizes audio tokens into 24 kHz waveforms |
+| **projector** | Projection layer used by TTS |
+
+---
+
+## 1. Environment & Build
+
+### 1.1 Dependencies
+
+- CMake 3.14+ and a C++17 compiler
+- GPU backend (auto-detected): Linux + NVIDIA → CUDA; macOS → Metal
+- (Optional) OpenSSL: this repository defaults to `LLAMA_OPENSSL=ON`, used for serving HTTPS. This option directly affects how `llama-omni-server` starts, see [5.1](#51-starting-the-server-important)
+- (For server video input) `ffmpeg`: needed to parse uploaded MP4s in `turn_based` mode
+
+### 1.2 Build
+
+```bash
+# Configure (CMake will auto-detect and enable CUDA / Metal)
+cmake -B build -DCMAKE_BUILD_TYPE=Release
+
+# Build the targets you need
+cmake --build build --config Release -j \
+    --target llama-omni-cli \
+             llama-omni-single-test-audio \
+             llama-omni-single-test-omni \
+             llama-omni-test-duplex \
+             llama-omni-server
+```
+
+Artifacts are placed in `build/bin/`:
+
+| Binary | Description |
+| --- | --- |
+| `llama-omni-cli` | CLI inference tool (Usage 1 in this doc) |
+| `llama-omni-single-test-audio` | Simplex · audio-only batch test |
+| `llama-omni-single-test-omni` | Simplex · audio + vision batch test |
+| `llama-omni-test-duplex` | Full-duplex test |
+| `llama-omni-server` | Omni HTTP/WebSocket server (Usage 3 in this doc) |
+
+> If you do not want HTTPS, add `-DLLAMA_OPENSSL=OFF` at configure time; `llama-omni-server` will then start with plain HTTP (no certificate needed).
+
+---
+
+## 2. Download the Model
+
+### 2.1 Directory layout (must be consistent)
+
+The CLI / tests / server only need the path to the **LLM** (`-m`); the other sub-models are auto-inferred from the following **fixed directory layout**, which must be kept consistent:
+
+```
+MiniCPM-o-4_5-gguf/
+├── MiniCPM-o-4_5-Q4_K_M.gguf         # LLM; can be swapped for F16 / Q8_0 / Q4_K_M etc.
+├── audio/
+│   └── MiniCPM-o-4_5-audio-F16.gguf
+├── vision/
+│   └── MiniCPM-o-4_5-vision-F16.gguf
+├── tts/
+│   ├── MiniCPM-o-4_5-tts-F16.gguf
+│   └── MiniCPM-o-4_5-projector-F16.gguf
+└── token2wav-gguf/                   # required when TTS is enabled
+    ├── encoder.gguf                  # ~144MB
+    ├── flow_matching.gguf            # ~437MB
+    ├── flow_extra.gguf               # ~13MB
+    ├── hifigan2.gguf                 # ~79MB
+    └── prompt_cache.gguf             # ~67MB
+```
+
+Notes:
+- **Pick any single LLM quantization**; you do not need to download all of them. VRAM/RAM reference: Q4_K_M ~9GB, Q8_0 ~13GB, F16 ~20GB (Full Omni).
+- The `audio/`, `vision/`, and `tts/` sub-directories are recommended to be downloaded together; `token2wav-gguf/` can be omitted only when using `--no-tts`.
+- If you only use a single modality (vision or audio), you may download only the corresponding sub-model, but keep the directory names unchanged.
+
+### 2.2 Option 1: Download official GGUF directly (recommended)
+
+- HuggingFace: <https://huggingface.co/openbmb/MiniCPM-o-4_5-gguf>
+- ModelScope: <https://modelscope.cn/models/OpenBMB/MiniCPM-o-4_5-gguf>
+
+```bash
+# HuggingFace (huggingface-cli)
+pip install -U "huggingface_hub[cli]"
+huggingface-cli download openbmb/MiniCPM-o-4_5-gguf \
+    --local-dir ./MiniCPM-o-4_5-gguf
+
+# Or ModelScope
+pip install -U modelscope
+modelscope download --model OpenBMB/MiniCPM-o-4_5-gguf \
+    --local_dir ./MiniCPM-o-4_5-gguf
+```
+
+After downloading, confirm the directory layout matches [2.1](#21-directory-layout-must-be-consistent) above (especially `token2wav-gguf/` and `tts/projector`).
+
+### 2.3 Option 2: Convert from PyTorch weights yourself
+
+First download the original weights (<https://huggingface.co/openbmb/MiniCPM-o-4_5>), then convert with the repository script:
+
+```bash
+# Edit the paths at the top of the script, then run
+#   MODEL_DIR   = PyTorch model directory
+#   OUTPUT_DIR  = output gguf directory
+bash ./tools/omni/convert/run_convert.sh
+```
+
+The script sequentially performs surgery (component splitting) → converts VPM/APM/LLM/TTS/projector → quantizes the LLM. Token2Wav must be converted separately following the instructions in `tools/omni/token2wav/`.
+
+---
+
+## 3. Usage 1: CLI (`llama-omni-cli`)
+
+The CLI is the most direct command-line entry point; pass the LLM path via `-m` and it will run a built-in test case and write the synthesized speech to `tools/omni/output/`.
+
+> It is recommended to run from the repository root, since the default reference audio and test data use relative paths (`tools/omni/assets/...`). For single-GPU runs you may add `CUDA_VISIBLE_DEVICES=0`.
+
+```bash
+export MODEL=/path/to/MiniCPM-o-4_5-gguf/MiniCPM-o-4_5-Q4_K_M.gguf
+
+# Basic usage (runs the built-in audio-only case by default; other sub-model paths are auto-inferred)
+CUDA_VISIBLE_DEVICES=0 ./build/bin/llama-omni-cli -m "$MODEL"
+
+# Specify an audio test case: <prefix> <count>, files named like <prefix>0000.wav
+CUDA_VISIBLE_DEVICES=0 ./build/bin/llama-omni-cli -m "$MODEL" \
+    --test tools/omni/assets/test_case/audio_test_case/audio_test_case_ 2
+
+# Omni mode (audio + vision, auto-matches a .jpg with the same name)
+CUDA_VISIBLE_DEVICES=0 ./build/bin/llama-omni-cli -m "$MODEL" --omni \
+    --test tools/omni/assets/test_case/omni_test_case/omni_test_case_ 9
+
+# Text-only output (disable TTS, no speech generated)
+CUDA_VISIBLE_DEVICES=0 ./build/bin/llama-omni-cli -m "$MODEL" --no-tts
+```
+
+### Common Arguments
+
+| Argument | Description |
+| --- | --- |
+| `-m <path>` | **Required**; path to the LLM GGUF (other sub-models are inferred from it) |
+| `--vision/--audio/--tts/--projector <path>` | Override the corresponding sub-model path |
+| `--ref-audio <path>` | Reference audio for voice cloning (default `tools/omni/assets/default_ref_audio/default_ref_audio.wav`) |
+| `-c, --ctx-size <n>` | Context length (default 4096) |
+| `-ngl <n>` | Number of GPU layers (default 99, i.e. offload as much as possible to GPU) |
+| `--no-tts` | Disable TTS, output text only |
+| `--omni` | Enable omni (audio + vision) |
+| `--test <prefix> <n>` | Specify the test data prefix and count |
+
+For the full list of arguments see `./build/bin/llama-omni-cli -h`.
+
+### Output
+
+Synthesized speech is written per round to `tools/omni/output/round_XXX/tts_wav/wav_*.wav`; text and debug info are in the sibling `llm_debug/` directory. Use `tools/omni/test/merge_wav.sh` to merge the shards into a single file.
+
+---
+
+## 4. Usage 2: Test Programs (`tools/omni/test/`)
+
+The three test programs share the same model auto-inference logic and `--test <prefix> <n>` syntax; they can be used for functional verification, result alignment, and performance stress testing.
+
+### 4.1 Simplex · audio-only `llama-omni-single-test-audio`
+
+Handles audio only: all chunks are prefilled synchronously and then decoded once together.
+
+```bash
+CUDA_VISIBLE_DEVICES=0 ./build/bin/llama-omni-single-test-audio -m "$MODEL" \
+    --test tools/omni/assets/test_case/audio_test_case/audio_test_case_ 2
+```
+
+### 4.2 Simplex · audio + vision `llama-omni-single-test-omni`
+
+Each chunk's `.wav` is paired with a `.jpg` of the same name (missing image degrades to audio-only).
+
+```bash
+CUDA_VISIBLE_DEVICES=0 ./build/bin/llama-omni-single-test-omni -m "$MODEL" \
+    --test tools/omni/assets/test_case/omni_test_case/omni_test_case_ 5
+```
+
+### 4.3 Duplex `llama-omni-test-duplex`
+
+Simulates full-duplex streaming input: frames are pushed at a fixed pace, and the model outputs a `<|speak|>` or `<|listen|>` token per frame.
+
+```bash
+# --stream-interval 1000 means one frame per second (simulating real streaming); 0 means continuous stress test with no delay
+CUDA_VISIBLE_DEVICES=0 ./build/bin/llama-omni-test-duplex -m "$MODEL" --omni \
+    --test tools/omni/assets/test_case/omni_test_case/omni_test_case_ 5 \
+    --stream-interval 1000
+```
+
+At the end it prints the per-frame decode/e2e timing and a speak/listen summary.
+
+> Test data lives in `tools/omni/assets/test_case/` (including `audio_test_case/`, `omni_test_case/`, etc.); files are named `<prefix>0000.wav`, `<prefix>0001.wav` and so on, and the argument `<n>` is the number of chunks to read.
+
+---
+
+## 5. Usage 3: Omni Server (`llama-omni-server`)
+
+`llama-omni-server` provides two sets of interfaces; the server-side logic is mainly in `tools/server/ws_handler.cpp`:
+
+- **WebSocket `/backend`**: modern protocol (session.init → input.append → event stream), which the Demo is built upon; supports both `turn_based` (turn-by-turn dialog) and `full_duplex` (full-duplex streaming) modes.
+- **Legacy HTTP (SSE)**: `/v1/stream/omni_init`, `/v1/stream/prefill`, `/v1/stream/decode`, etc., convenient for manual debugging with curl.
+- **Health checks**: `GET /health`, `GET /v1/health`.
+
+### 5.1 Starting the server (important)
+
+> This repository defaults to `LLAMA_OPENSSL=ON`, and the server starts with HTTPS (SSLServer). If no certificate is provided, the process exits immediately after printing `Omni HTTP server starting...`, and the port is not listened on. Choose one of the two approaches below:
+
+**Option A: Provide a certificate and start with HTTPS (required by the Demo / browsers)**
+
+```bash
+# Generate a self-signed certificate (for local testing)
+mkdir -p /tmp/omni_ssl
+openssl req -x509 -newkey rsa:2048 -nodes -days 3650 \
+    -keyout /tmp/omni_ssl/key.pem -out /tmp/omni_ssl/cert.pem \
+    -subj "/CN=localhost"
+
+# Start (-m points to the LLM; other sub-models are auto-inferred)
+export MODEL=/path/to/MiniCPM-o-4_5-gguf/MiniCPM-o-4_5-Q4_K_M.gguf
+CUDA_VISIBLE_DEVICES=0 ./build/bin/llama-omni-server \
+    -m "$MODEL" --host 0.0.0.0 --port 28099 -c 4096 -ngl 99 \
+    --ssl-cert-file /tmp/omni_ssl/cert.pem \
+    --ssl-key-file  /tmp/omni_ssl/key.pem
+```
+
+**Option B: Disable OpenSSL at configure time and start with plain HTTP**
+
+```bash
+cmake -B build -DCMAKE_BUILD_TYPE=Release -DLLAMA_OPENSSL=OFF
+cmake --build build --config Release -j --target llama-omni-server
+# Afterwards, no --ssl-* arguments are needed; access via http://
+```
+
+Other notes:
+- **Port in use**: if the port is already occupied by another process, the server will fail to bind and exit. Switch to a free port or release the occupied one first.
+- **Lazy model loading**: the server itself starts quickly, but the model is only loaded on the first WebSocket session / first `omni_init` call, so the first call takes 10–60s to load.
+
+Verify a successful start:
+
+```bash
+# For HTTPS (Option A) use -k to skip self-signed certificate verification
+curl -sk https://127.0.0.1:28099/health
+# → {"engine":"comni","status":"ok"}
+```
+
+### 5.2 Calling via WebSocket `/backend` (modern protocol / used by the Demo)
+
+Message format:
+
+- Upstream first frame `session.init` (`payload.mode` = `turn_based` or `full_duplex`; `payload.use_tts` controls whether audio is emitted)
+- Upstream `input.append` (`turn_based` uses `input.messages`; `full_duplex` uses `input.audio` + optional `input.video_frames`)
+- Downstream events: `session.created` → `response.output.delta` (`kind` = `text`/`audio`/`listen`) → `response.done` → `session.closed`
+
+A minimal `turn_based` text-only example (Python, `pip install websockets`):
+
+```python
+import asyncio, json, ssl, websockets
+
+async def main():
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE  # for self-signed certs; in HTTP mode use ws:// and drop the ssl arg
+    async with websockets.connect("wss://127.0.0.1:28099/backend", ssl=ctx, max_size=None) as ws:
+        await ws.send(json.dumps({
+            "type": "session.init",
+            "payload": {"mode": "turn_based", "use_tts": False}
+        }))
+        print(json.loads(await ws.recv())["type"])   # session.created
+
+        await ws.send(json.dumps({
+            "type": "input.append",
+            "input": {
+                "messages": [{"role": "user", "content": "Introduce yourself in one sentence."}],
+                "streaming": True,
+                "generation": {"max_new_tokens": 128}
+            }
+        }))
+
+        text = ""
+        while True:
+            m = json.loads(await ws.recv())
+            if m["type"] == "response.output.delta" and m.get("kind") == "text":
+                text += m.get("text", "")
+            elif m["type"] == "response.done":
+                print("Reply:", m.get("text")); break
+
+asyncio.run(main())
+```
+
+- In `turn_based`, you can include `image`/`audio`/`video` content items in `messages[].content` for multimodal Q&A; when `input.use_tts_template=true`, the reply carries synthesized speech (`response.done.audio`, base64 float32 PCM).
+- In `full_duplex`, each `input.append` sends 1 second of audio (+ optional video frames); the server decides speak/listen at 1 Hz for real-time conversation.
+
+### 5.3 Calling via Legacy HTTP (SSE) (manual debugging with curl)
+
+Call order: `omni_init` → loop (`prefill` → `decode`). `decode` returns an SSE text stream, and the synthesized speech is written under `output_dir`.
+
+```bash
+export B=https://127.0.0.1:28099    # In HTTP mode change to http:// and drop -k
+
+# 1) Initialize (loads the model on first call; the system prompt prefill for index=0 is done internally)
+curl -sk -X POST $B/v1/stream/omni_init -H 'Content-Type: application/json' \
+    -d '{"media_type":1,"use_tts":true,"output_dir":"./tools/omni/output_server"}'
+
+# 2) Send a user audio segment (audio_path_prefix is a server-visible file path; cnt is the index, starting from 1)
+curl -sk -X POST $B/v1/stream/prefill -H 'Content-Type: application/json' \
+    -d '{"audio_path_prefix":"tools/omni/assets/test_case/audio_test_case/audio_test_case_0000.wav","cnt":1}'
+
+# 3) Trigger generation (SSE stream)
+curl -sk -N -X POST $B/v1/stream/decode -H 'Content-Type: application/json' \
+    -d '{"stream":true,"debug_dir":"./tools/omni/output_server"}'
+```
+
+The SSE response looks like (note the text field is **`content`**, not `text`):
+
+```
+data: {"content":"Once upon a time there was a mountain","end_of_turn":false,"is_listen":false,"stop":false}
+data: {"content":"","end_of_turn":true,"is_listen":false,"stop":true}
+data: [DONE]
+```
+
+| Field | Description |
+| --- | --- |
+| `content` | Text fragment (may be empty; filter before display) |
+| `is_listen` | `true` means the model has switched to the listening state |
+| `stop` | `true` means this turn of generation has ended |
+
+> `media_type`: `1` = audio only, `2` = audio + vision; `cnt=0` of `prefill` is already handled internally by `omni_init`, so your own count starts from `1`.
+
+---
+
+# Part 2: Demo
+
+The MiniCPM-o 4.5 Demo is a **full-duplex real-time audio/video conversation** web app, available both as an online experience and for local deployment.
+
+## 1. HuggingFace Space (online experience)
+
+Open the official hosted Demo for an online experience: <https://huggingface.co/spaces/openbmb/MiniCPM-o-4_5-Demo> (or visit <https://minicpmo45.modelbest.cn/> directly).
+
+## 2. Local Deployment: MiniCPM-o-Demo (with this repository's C++ backend)
+
+To run the full audio/video call frontend on your own machine backed by your self-built `llama-omni-server`, use the official Demo repository:
+
+- Repository: <https://github.com/OpenBMB/MiniCPM-o-Demo> (use the default `main` branch)
+
+> Branch note: the C++ backend (llama.cpp-omni) has been merged into `main`, which supports both the PyTorch backend and the C++ backend. The old `Comni` branch is deprecated; use `main` instead.
+
+The Demo uses a gateway + worker + backend architecture, where worker/gateway is a generic Python orchestration layer, and the backend can be either PyTorch (`py_backend/server.py`) or C++ (this repository's `llama-omni-server`):
+
+```
+Browser ⇄ gateway.py (HTTPS, :8006) ⇄ worker.py (:22400) ⇄ llama-omni-server (HTTP, :22500)
+```
+
+### Option 1: Docker Compose (officially recommended)
+
+The Demo provides `docker-compose.cpp.yml` for the C++ backend, which starts gateway + cpp-worker-backend with a single command. The cpp-worker-backend image automatically clones and compiles `tc-mb/llama.cpp-omni` inside the container, so no local build is required.
+
+```bash
+git clone https://github.com/OpenBMB/MiniCPM-o-Demo.git
+cd MiniCPM-o-Demo
+
+# Generate a self-signed certificate (for gateway HTTPS)
+mkdir -p certs data
+openssl req -x509 -newkey rsa:2048 -nodes -days 365 \
+    -keyout certs/key.pem -out certs/cert.pem -subj "/CN=minicpm-o"
+
+# Build and start (GGUF_MODEL_HOST_PATH points to the host GGUF directory, mounted read-only)
+GGUF_MODEL_HOST_PATH=/path/to/MiniCPM-o-4_5-gguf \
+GATEWAY_HOST_PORT=8006 \
+CPP_GPU_ID=0 \
+docker compose -f docker-compose.cpp.yml up -d --build
+
+docker compose -f docker-compose.cpp.yml logs -f cpp-worker-backend   # watch backend loading
+# Open https://<host>:8006/ in a browser
+```
+
+Docker notes:
+- **Docker Hub access required**: the image is based on `docker/dockerfile:1` and `nvidia/cuda:*` base images; if the machine cannot reach `docker.io` (common in offline / China environments), the build will time out while pulling base images. Configure a registry mirror or fall back to Option 2.
+- **CUDA architecture**: `docker/Dockerfile.cpp-worker-backend` defaults to `CMAKE_CUDA_ARCHITECTURES=80;120` (A100 / Blackwell) and does not include Ada (sm_89, e.g. RTX 40 series). If you get `no kernel image is available for execution on the device` at runtime, add `89` to the arg in that Dockerfile and rebuild.
+- Certificates are only used at the **gateway** layer (HTTPS terminates at the gateway); the `llama-omni-server` inside the container is plain HTTP and needs no certificate (see below).
+
+### Option 2: Bare-metal (no Docker)
+
+Suitable for debugging or environments without Docker Hub access. Start the three processes in order:
+
+```bash
+# 0) First build this repository's llama-omni-server (see Part 1, Section 1)
+#    The backend must be the plain HTTP version: the demo's worker connects to the backend via ws://
+#    and does not skip self-signed certificate verification, so it cannot reach an HTTPS backend.
+#    Therefore, disable OpenSSL at build time:
+#       cmake -B build -DCMAKE_BUILD_TYPE=Release -DLLAMA_OPENSSL=OFF
+#       cmake --build build --config Release -j --target llama-omni-server
+
+git clone https://github.com/OpenBMB/MiniCPM-o-Demo.git
+cd MiniCPM-o-Demo
+
+# 1) Install worker/gateway dependencies (C++ backend mode does not need torch; lightweight)
+python3 -m venv .venv-cpp && . .venv-cpp/bin/activate
+pip install "fastapi>=0.128.0" "httpx>=0.28.0" "numpy>=2.2.0" "pydantic>=2.11.0" \
+            python-multipart "uvicorn>=0.40.0" "websockets>=16.0"
+
+export MODEL=/path/to/MiniCPM-o-4_5-gguf/MiniCPM-o-4_5-Q4_K_M.gguf
+
+# 2) Start the backend llama-omni-server (HTTP, :22500)
+CUDA_VISIBLE_DEVICES=0 /path/to/llama.cpp-omni/build/bin/llama-omni-server \
+    -m "$MODEL" --host 127.0.0.1 --port 22500 -c 8192 -ngl 99 &
+
+# 3) Start the worker (remote backend mode, pointing at the backend)
+CUDA_VISIBLE_DEVICES=0 PYTHONPATH=. python worker.py \
+    --host 0.0.0.0 --port 22400 --gpu-id 0 \
+    --backend-server-url http://127.0.0.1:22500 &
+
+# 4) Start the gateway (use --http for local debugging; switch back to default HTTPS for browser camera/mic)
+python gateway.py --host 0.0.0.0 --port 8006 --http --workers localhost:22400 &
+
+# 5) Verify
+curl http://127.0.0.1:22500/health   # backend: {"engine":"comni","status":"ok"}
+curl http://127.0.0.1:22400/health   # worker: {"status":"healthy","worker_status":"idle",...}
+curl http://127.0.0.1:8006/health    # gateway: {"status":"healthy",...}
+# Open http://<host>:8006/ in a browser
+```
+
+Notes:
+- The backend must be the plain HTTP version (`-DLLAMA_OPENSSL=OFF`). This also explains why the official Docker image does not install `libssl-dev` — precisely so that `llama-omni-server` is compiled as the HTTP version.
+- **Port conflicts**: the default ports for worker, backend, and gateway (22400 / 22500 / 8006) may conflict on shared machines; the process silently exits when a port is taken, so use free ports instead.
+- **Camera/mic require HTTPS**: when gateway runs with `--http`, the browser disables media devices and only text input works; for real use, drop `--http` (defaults to HTTPS, requires `certs/cert.pem`, `certs/key.pem`).
+- In C++ backend mode, the worker does not load any PyTorch model; it just forwards `session.init / input.append` to the backend. The exposed WS routes are `/v1/worker/chat` (turn_based) and `/v1/worker/duplex` (full_duplex).
+
+For more details see the Demo repository's `README.md` / `README_zh.md` (`main` branch) and `docker-compose.cpp.yml`, `docker/entrypoint-cpp-worker-backend.sh`.
+
+---
+
+## References
+
+- This repository's upstream: <https://github.com/tc-mb/llama.cpp-omni>
+- Model (PyTorch): <https://huggingface.co/openbmb/MiniCPM-o-4_5>
+- Model (GGUF): <https://huggingface.co/openbmb/MiniCPM-o-4_5-gguf> · <https://modelscope.cn/models/OpenBMB/MiniCPM-o-4_5-gguf>
+- Online Demo: <https://minicpmo45.modelbest.cn/>
+- Demo repository: <https://github.com/OpenBMB/MiniCPM-o-Demo> (`main` branch)
+- HF Space: <https://huggingface.co/spaces/openbmb/MiniCPM-o-4_5-Demo>

--- a/deployment/llama.cpp-omni/minicpmo_4_5_llamacpp_omni_zh.md
+++ b/deployment/llama.cpp-omni/minicpmo_4_5_llamacpp_omni_zh.md
@@ -1,0 +1,468 @@
+# MiniCPM-o 4.5 · llama.cpp-omni 使用文档
+
+本文档介绍如何基于本仓库（**llama.cpp-omni**）运行 MiniCPM-o 4.5 的多模态推理，涵盖三种主要用法：
+
+1. **命令行 CLI**（`tools/omni/omni-cli.cpp` → `llama-omni-cli`）
+2. **测试程序**（`tools/omni/test/` → 单工音频 / 单工 omni / 双工）
+3. **Omni 服务**（`tools/server/ws_handler.cpp` 等 → `llama-omni-server`）
+
+以及配套的 **Demo**（HuggingFace Space 与可本地部署的 MiniCPM-o-Demo）。
+
+> 本文档示例在 Linux + NVIDIA CUDA（RTX 4090）环境下验证；macOS 将 `CUDA` 替换为 `Metal`，命令相同。
+
+---
+
+## 目录
+
+- [第一部分：llama.cpp-omni（本仓库）](#第一部分llamacpp-omni本仓库)
+  - [1. 环境与构建](#1-环境与构建)
+  - [2. 下载模型](#2-下载模型)
+  - [3. 用法一：CLI](#3-用法一cli-llama-omni-cli)
+  - [4. 用法二：测试程序](#4-用法二测试程序-toolsomnitest)
+  - [5. 用法三：Omni 服务](#5-用法三omni-服务-llama-omni-server)
+- [第二部分：Demo](#第二部分demo)
+
+---
+
+# 第一部分：llama.cpp-omni（本仓库）
+
+llama.cpp-omni 把 MiniCPM-o 4.5 拆成多个独立的 GGUF 模块协同推理：
+
+| 模块 | 作用 |
+| --- | --- |
+| **LLM** | 主语言模型（Qwen3-8B），接收视觉/音频 embedding 生成文本 token |
+| **VPM** (vision) | 视觉编码器（SigLip2 + Resampler），把图像编码进 LLM 隐空间 |
+| **APM** (audio) | 音频编码器（Whisper），把 16kHz 音频编码进 LLM 隐空间 |
+| **TTS** | 文本转语音模型，把 LLM 隐状态生成音频 token |
+| **Token2Wav** | 声码器（Flow Matching + HiFiGAN），把音频 token 合成 24kHz 波形 |
+| **projector** | TTS 使用的投影层 |
+
+---
+
+## 1. 环境与构建
+
+### 1.1 依赖
+
+- CMake 3.14 及以上、C++17 编译器
+- GPU 后端（自动检测）：Linux + NVIDIA → CUDA；macOS → Metal
+- （可选）OpenSSL：本仓库默认 `LLAMA_OPENSSL=ON`，用于服务 HTTPS。该选项直接影响 `llama-omni-server` 的启动方式，见 [5.1](#51-启动服务重点)
+- （服务的视频输入）`ffmpeg`：`turn_based` 模式下解析上传的 MP4 需要
+
+### 1.2 构建
+
+```bash
+# 配置（CMake 会自动探测并启用 CUDA / Metal）
+cmake -B build -DCMAKE_BUILD_TYPE=Release
+
+# 构建需要用到的目标
+cmake --build build --config Release -j \
+    --target llama-omni-cli \
+             llama-omni-single-test-audio \
+             llama-omni-single-test-omni \
+             llama-omni-test-duplex \
+             llama-omni-server
+```
+
+产物位于 `build/bin/`：
+
+| 二进制 | 说明 |
+| --- | --- |
+| `llama-omni-cli` | 命令行推理工具（本文档用法一） |
+| `llama-omni-single-test-audio` | 单工·纯音频批量测试 |
+| `llama-omni-single-test-omni` | 单工·音频+视觉批量测试 |
+| `llama-omni-test-duplex` | 双工（full-duplex）测试 |
+| `llama-omni-server` | Omni HTTP/WebSocket 服务（本文档用法三） |
+
+> 若不想启用 HTTPS，配置时加 `-DLLAMA_OPENSSL=OFF`，`llama-omni-server` 就会用普通 HTTP 启动（无需证书）。
+
+---
+
+## 2. 下载模型
+
+### 2.1 目录结构（必须一致）
+
+CLI / 测试 / 服务都只需要传 **LLM 的路径**（`-m`），其它子模型会按下面的**固定目录结构**自动推断，需保持一致：
+
+```
+MiniCPM-o-4_5-gguf/
+├── MiniCPM-o-4_5-Q4_K_M.gguf         # LLM，可换 F16 / Q8_0 / Q4_K_M 等量化
+├── audio/
+│   └── MiniCPM-o-4_5-audio-F16.gguf
+├── vision/
+│   └── MiniCPM-o-4_5-vision-F16.gguf
+├── tts/
+│   ├── MiniCPM-o-4_5-tts-F16.gguf
+│   └── MiniCPM-o-4_5-projector-F16.gguf
+└── token2wav-gguf/                   # 开启 TTS 时必需
+    ├── encoder.gguf                  # ~144MB
+    ├── flow_matching.gguf            # ~437MB
+    ├── flow_extra.gguf               # ~13MB
+    ├── hifigan2.gguf                 # ~79MB
+    └── prompt_cache.gguf             # ~67MB
+```
+
+说明：
+- **LLM 量化任选一种**即可，无需全部下载。显存/内存参考：Q4_K_M 约 9GB、Q8_0 约 13GB、F16 约 20GB（Full Omni）。
+- `audio/`、`vision/`、`tts/` 三个子目录建议一并下载；仅使用 `--no-tts` 时可省略 `token2wav-gguf/`。
+- 若只使用视觉或音频单一模态，可只下载对应子模型，但请保持目录名称不变。
+
+### 2.2 方式一：直接下载官方 GGUF（推荐）
+
+- HuggingFace：<https://huggingface.co/openbmb/MiniCPM-o-4_5-gguf>
+- ModelScope：<https://modelscope.cn/models/OpenBMB/MiniCPM-o-4_5-gguf>
+
+```bash
+# HuggingFace（huggingface-cli）
+pip install -U "huggingface_hub[cli]"
+huggingface-cli download openbmb/MiniCPM-o-4_5-gguf \
+    --local-dir ./MiniCPM-o-4_5-gguf
+
+# 或 ModelScope
+pip install -U modelscope
+modelscope download --model OpenBMB/MiniCPM-o-4_5-gguf \
+    --local_dir ./MiniCPM-o-4_5-gguf
+```
+
+下载后确认目录结构与上面 [2.1](#21-目录结构必须一致) 一致（尤其是 `token2wav-gguf/` 和 `tts/projector`）。
+
+### 2.3 方式二：从 PyTorch 权重自行转换
+
+先下载原始权重（<https://huggingface.co/openbmb/MiniCPM-o-4_5>），再用仓库脚本转换：
+
+```bash
+# 编辑脚本顶部路径后运行
+#   MODEL_DIR   = PyTorch 模型目录
+#   OUTPUT_DIR  = 输出 gguf 目录
+bash ./tools/omni/convert/run_convert.sh
+```
+
+脚本会依次做 surgery（拆分组件）→ 转换 VPM/APM/LLM/TTS/projector → 量化 LLM。Token2Wav 需按 `tools/omni/token2wav/` 说明单独转换。
+
+---
+
+## 3. 用法一：CLI (`llama-omni-cli`)
+
+CLI 是最直接的命令行入口，`-m` 传 LLM 路径即可，会运行一段内置测试用例并把合成语音写到 `tools/omni/output/`。
+
+> 建议在仓库根目录运行，默认参考音频、测试数据均为相对路径（`tools/omni/assets/...`）。单卡运行可加 `CUDA_VISIBLE_DEVICES=0`。
+
+```bash
+export MODEL=/path/to/MiniCPM-o-4_5-gguf/MiniCPM-o-4_5-Q4_K_M.gguf
+
+# 基本用法（默认运行内置纯音频用例，自动推断其它子模型路径）
+CUDA_VISIBLE_DEVICES=0 ./build/bin/llama-omni-cli -m "$MODEL"
+
+# 指定音频测试用例：<前缀> <数量>，文件形如 <前缀>0000.wav
+CUDA_VISIBLE_DEVICES=0 ./build/bin/llama-omni-cli -m "$MODEL" \
+    --test tools/omni/assets/test_case/audio_test_case/audio_test_case_ 2
+
+# Omni 模式（音频 + 视觉，自动匹配同名 .jpg）
+CUDA_VISIBLE_DEVICES=0 ./build/bin/llama-omni-cli -m "$MODEL" --omni \
+    --test tools/omni/assets/test_case/omni_test_case/omni_test_case_ 9
+
+# 纯文本输出（关闭 TTS，不生成语音）
+CUDA_VISIBLE_DEVICES=0 ./build/bin/llama-omni-cli -m "$MODEL" --no-tts
+```
+
+### 常用参数
+
+| 参数 | 说明 |
+| --- | --- |
+| `-m <path>` | **必填**，LLM GGUF 路径（其它子模型据此推断） |
+| `--vision/--audio/--tts/--projector <path>` | 覆盖对应子模型路径 |
+| `--ref-audio <path>` | 声音克隆的参考音频（默认 `tools/omni/assets/default_ref_audio/default_ref_audio.wav`） |
+| `-c, --ctx-size <n>` | 上下文长度（默认 4096） |
+| `-ngl <n>` | GPU 层数（默认 99，即尽量全放 GPU） |
+| `--no-tts` | 关闭 TTS，只输出文本 |
+| `--omni` | 开启 omni（音频+视觉） |
+| `--test <prefix> <n>` | 指定测试数据前缀与数量 |
+
+完整参数见 `./build/bin/llama-omni-cli -h`。
+
+### 输出
+
+合成语音按轮次写到 `tools/omni/output/round_XXX/tts_wav/wav_*.wav`，文本与调试信息在同级 `llm_debug/`。可用 `tools/omni/test/merge_wav.sh` 把分片合并成整段。
+
+---
+
+## 4. 用法二：测试程序 (`tools/omni/test/`)
+
+三个测试程序共用相同的模型自动推断逻辑和 `--test <prefix> <n>` 语法，可用于功能验证、结果对齐与性能压测。
+
+### 4.1 单工·纯音频 `llama-omni-single-test-audio`
+
+只处理音频：所有 chunk 同步 prefill 后统一 decode 一次。
+
+```bash
+CUDA_VISIBLE_DEVICES=0 ./build/bin/llama-omni-single-test-audio -m "$MODEL" \
+    --test tools/omni/assets/test_case/audio_test_case/audio_test_case_ 2
+```
+
+### 4.2 单工·音频+视觉 `llama-omni-single-test-omni`
+
+每个 chunk 的 `.wav` 与同名 `.jpg` 配对（缺图则退化为纯音频）。
+
+```bash
+CUDA_VISIBLE_DEVICES=0 ./build/bin/llama-omni-single-test-omni -m "$MODEL" \
+    --test tools/omni/assets/test_case/omni_test_case/omni_test_case_ 5
+```
+
+### 4.3 双工 `llama-omni-test-duplex`
+
+模拟 full-duplex 流式输入：按固定节奏推送帧，模型逐帧输出 `<|speak|>` 或 `<|listen|>` 标记。
+
+```bash
+# --stream-interval 1000 表示每 1 秒输入一帧（模拟真实流式）；0 表示无间隔连续压测
+CUDA_VISIBLE_DEVICES=0 ./build/bin/llama-omni-test-duplex -m "$MODEL" --omni \
+    --test tools/omni/assets/test_case/omni_test_case/omni_test_case_ 5 \
+    --stream-interval 1000
+```
+
+结束会打印每帧 decode/e2e 耗时与 speak/listen 汇总。
+
+> 测试数据位于 `tools/omni/assets/test_case/`（含 `audio_test_case/`、`omni_test_case/` 等）；文件命名规则为 `<前缀>0000.wav`、`<前缀>0001.wav` 依次递增，参数 `<n>` 为要读取的 chunk 数量。
+
+---
+
+## 5. 用法三：Omni 服务 (`llama-omni-server`)
+
+`llama-omni-server` 同时提供两套接口，服务端逻辑主要在 `tools/server/ws_handler.cpp`：
+
+- **WebSocket `/backend`**：现代协议（session.init → input.append → 事件流），Demo 即基于此协议；支持 `turn_based`（按轮对话）与 `full_duplex`（全双工流式）两种模式。
+- **Legacy HTTP（SSE）**：`/v1/stream/omni_init`、`/v1/stream/prefill`、`/v1/stream/decode` 等，便于使用 curl 手动调试。
+- **健康检查**：`GET /health`、`GET /v1/health`。
+
+### 5.1 启动服务（重点）
+
+> 本仓库默认 `LLAMA_OPENSSL=ON`，服务以 HTTPS（SSLServer）启动。若不提供证书，进程会在打印 `Omni HTTP server starting...` 后直接退出，端口不会监听。以下两种方式任选其一：
+
+**方式 A：提供证书，以 HTTPS 启动（Demo/浏览器均要求 HTTPS）**
+
+```bash
+# 生成自签名证书（本地测试用）
+mkdir -p /tmp/omni_ssl
+openssl req -x509 -newkey rsa:2048 -nodes -days 3650 \
+    -keyout /tmp/omni_ssl/key.pem -out /tmp/omni_ssl/cert.pem \
+    -subj "/CN=localhost"
+
+# 启动（-m 传 LLM，其它子模型自动推断）
+export MODEL=/path/to/MiniCPM-o-4_5-gguf/MiniCPM-o-4_5-Q4_K_M.gguf
+CUDA_VISIBLE_DEVICES=0 ./build/bin/llama-omni-server \
+    -m "$MODEL" --host 0.0.0.0 --port 28099 -c 4096 -ngl 99 \
+    --ssl-cert-file /tmp/omni_ssl/cert.pem \
+    --ssl-key-file  /tmp/omni_ssl/key.pem
+```
+
+**方式 B：配置时关闭 OpenSSL，以普通 HTTP 启动**
+
+```bash
+cmake -B build -DCMAKE_BUILD_TYPE=Release -DLLAMA_OPENSSL=OFF
+cmake --build build --config Release -j --target llama-omni-server
+# 之后启动不需要 --ssl-* 参数，用 http:// 访问
+```
+
+其它注意事项：
+- **端口占用**：若端口已被其它进程占用，服务会绑定失败并退出。请更换端口或先释放占用。
+- **模型懒加载**：服务本身启动很快，但模型在首个 WebSocket 会话 / 首次 `omni_init` 调用时才加载，因此首次调用会有 10–60s 的加载耗时。
+
+验证启动成功：
+
+```bash
+# HTTPS（方式 A）用 -k 跳过自签证书校验
+curl -sk https://127.0.0.1:28099/health
+# → {"engine":"comni","status":"ok"}
+```
+
+### 5.2 用 WebSocket `/backend` 调用（现代协议 / Demo 所用）
+
+消息格式：
+
+- 上行首帧 `session.init`（`payload.mode` = `turn_based` 或 `full_duplex`，`payload.use_tts` 控制是否出声）
+- 上行 `input.append`（`turn_based` 用 `input.messages`；`full_duplex` 用 `input.audio` + 可选 `input.video_frames`）
+- 下行事件：`session.created` → `response.output.delta`（`kind` = `text`/`audio`/`listen`）→ `response.done` → `session.closed`
+
+一个最小的 `turn_based` 纯文本示例（Python，`pip install websockets`）：
+
+```python
+import asyncio, json, ssl, websockets
+
+async def main():
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE  # 自签证书用；HTTP 模式改用 ws:// 且去掉 ssl 参数
+    async with websockets.connect("wss://127.0.0.1:28099/backend", ssl=ctx, max_size=None) as ws:
+        await ws.send(json.dumps({
+            "type": "session.init",
+            "payload": {"mode": "turn_based", "use_tts": False}
+        }))
+        print(json.loads(await ws.recv())["type"])   # session.created
+
+        await ws.send(json.dumps({
+            "type": "input.append",
+            "input": {
+                "messages": [{"role": "user", "content": "用一句话介绍你自己"}],
+                "streaming": True,
+                "generation": {"max_new_tokens": 128}
+            }
+        }))
+
+        text = ""
+        while True:
+            m = json.loads(await ws.recv())
+            if m["type"] == "response.output.delta" and m.get("kind") == "text":
+                text += m.get("text", "")
+            elif m["type"] == "response.done":
+                print("回复:", m.get("text")); break
+
+asyncio.run(main())
+```
+
+- `turn_based` 可在 `messages[].content` 里带 `image`/`audio`/`video` 内容项做多模态问答；`input.use_tts_template=true` 时回复会带合成语音（`response.done.audio`，base64 float32 PCM）。
+- `full_duplex` 每次 `input.append` 送 1 秒音频（+可选视频帧），服务端按 1Hz 决定说话/倾听，用于实时对话。
+
+### 5.3 用 Legacy HTTP（SSE）调用（curl 手动调试）
+
+调用顺序：`omni_init` → 循环（`prefill` → `decode`）。`decode` 返回 SSE 文本流，合成语音写到 `output_dir` 下。
+
+```bash
+export B=https://127.0.0.1:28099    # HTTP 模式改成 http:// 并去掉 -k
+
+# 1) 初始化（首次会加载模型，内部已完成 index=0 的系统 prompt prefill）
+curl -sk -X POST $B/v1/stream/omni_init -H 'Content-Type: application/json' \
+    -d '{"media_type":1,"use_tts":true,"output_dir":"./tools/omni/output_server"}'
+
+# 2) 发送一段用户音频（audio_path_prefix 为服务端可见的文件路径，cnt 为序号，从 1 开始）
+curl -sk -X POST $B/v1/stream/prefill -H 'Content-Type: application/json' \
+    -d '{"audio_path_prefix":"tools/omni/assets/test_case/audio_test_case/audio_test_case_0000.wav","cnt":1}'
+
+# 3) 触发生成（SSE 流）
+curl -sk -N -X POST $B/v1/stream/decode -H 'Content-Type: application/json' \
+    -d '{"stream":true,"debug_dir":"./tools/omni/output_server"}'
+```
+
+SSE 返回形如（注意文本字段是 **`content`** 而非 `text`）：
+
+```
+data: {"content":"从前有座山，山里有座庙","end_of_turn":false,"is_listen":false,"stop":false}
+data: {"content":"","end_of_turn":true,"is_listen":false,"stop":true}
+data: [DONE]
+```
+
+| 字段 | 说明 |
+| --- | --- |
+| `content` | 文本片段（可能为空，展示前先过滤） |
+| `is_listen` | `true` 表示模型转入倾听状态 |
+| `stop` | `true` 表示本轮生成结束 |
+
+> `media_type`：`1` = 纯音频，`2` = 音频+视觉；`prefill` 的 `cnt=0` 已由 `omni_init` 内部处理，自己的计数从 `1` 开始。
+
+---
+
+# 第二部分：Demo
+
+MiniCPM-o 4.5 的 Demo 是一套**全双工音视频实时对话**的 Web 应用，分为在线体验与本地部署两种方式。
+
+## 1. HuggingFace Space（在线体验）
+
+打开即可在线体验官方托管的 Demo：<https://huggingface.co/spaces/openbmb/MiniCPM-o-4_5-Demo>（或直接访问 <https://minicpmo45.modelbest.cn/>）。
+
+## 2. 本地部署：MiniCPM-o-Demo（配合本仓库 C++ 后端）
+
+如需在本机基于自建的 `llama-omni-server` 运行完整的音视频通话前端，使用官方 Demo 仓库：
+
+- 仓库：<https://github.com/OpenBMB/MiniCPM-o-Demo>（使用默认的 `main` 分支）
+
+> 分支说明：C++ 后端（llama.cpp-omni）已合并进 `main`，`main` 同时支持 PyTorch 后端和 C++ 后端。旧 `Comni` 分支已废弃，统一使用 `main`。
+
+Demo 采用 gateway + worker + backend 架构，worker/gateway 是通用的 Python 编排层，后端可选 PyTorch（`py_backend/server.py`）或 C++（本仓库的 `llama-omni-server`）：
+
+```
+浏览器 ⇄ gateway.py（HTTPS，:8006）⇄ worker.py（:22400）⇄ llama-omni-server（HTTP，:22500）
+```
+
+### 方式一：Docker Compose（官方推荐）
+
+Demo 为 C++ 后端提供了 `docker-compose.cpp.yml`，一条命令启动 gateway + cpp-worker-backend。cpp-worker-backend 镜像会在容器内自动克隆并编译 `tc-mb/llama.cpp-omni`，无需本机预先构建。
+
+```bash
+git clone https://github.com/OpenBMB/MiniCPM-o-Demo.git
+cd MiniCPM-o-Demo
+
+# 生成自签名证书（gateway 的 HTTPS 用）
+mkdir -p certs data
+openssl req -x509 -newkey rsa:2048 -nodes -days 365 \
+    -keyout certs/key.pem -out certs/cert.pem -subj "/CN=minicpm-o"
+
+# 构建并启动（GGUF_MODEL_HOST_PATH 指向宿主机的 GGUF 目录，只读挂载）
+GGUF_MODEL_HOST_PATH=/path/to/MiniCPM-o-4_5-gguf \
+GATEWAY_HOST_PORT=8006 \
+CPP_GPU_ID=0 \
+docker compose -f docker-compose.cpp.yml up -d --build
+
+docker compose -f docker-compose.cpp.yml logs -f cpp-worker-backend   # 看后端加载
+# 浏览器打开 https://<host>:8006/
+```
+
+Docker 方式注意事项：
+- **需要能访问 Docker Hub**：镜像基于 `docker/dockerfile:1` 与 `nvidia/cuda:*` 基础镜像；若机器访问不了 `docker.io`（离线/国内环境常见），构建会在拉取基础镜像时超时失败。需自行配置 registry 镜像源或改用方式二。
+- **CUDA 架构**：`docker/Dockerfile.cpp-worker-backend` 默认 `CMAKE_CUDA_ARCHITECTURES=80;120`（A100 / Blackwell），未包含 Ada（sm_89，如 RTX 40 系列）。若运行时报 `no kernel image is available for execution on the device`，在该 Dockerfile 的 arg 中加上 `89` 重新构建。
+- 证书只在 **gateway** 层使用（HTTPS 终结在 gateway）；容器内的 `llama-omni-server` 是普通 HTTP，无需证书（见下方说明）。
+
+### 方式二：Bare-metal（无需 Docker）
+
+适用于调试或无法访问 Docker Hub 的场景。三个进程依次启动：
+
+```bash
+# 0) 先构建本仓库的 llama-omni-server（见第一部分第 1 节）
+#    后端需为普通 HTTP 版：demo 的 worker 用 ws:// 连后端、且不会跳过自签证书校验，
+#    连不上 HTTPS 后端。因此构建时需关闭 OpenSSL：
+#       cmake -B build -DCMAKE_BUILD_TYPE=Release -DLLAMA_OPENSSL=OFF
+#       cmake --build build --config Release -j --target llama-omni-server
+
+git clone https://github.com/OpenBMB/MiniCPM-o-Demo.git
+cd MiniCPM-o-Demo
+
+# 1) 装 worker/gateway 依赖（C++ 后端模式无需 torch，轻量）
+python3 -m venv .venv-cpp && . .venv-cpp/bin/activate
+pip install "fastapi>=0.128.0" "httpx>=0.28.0" "numpy>=2.2.0" "pydantic>=2.11.0" \
+            python-multipart "uvicorn>=0.40.0" "websockets>=16.0"
+
+export MODEL=/path/to/MiniCPM-o-4_5-gguf/MiniCPM-o-4_5-Q4_K_M.gguf
+
+# 2) 启动后端 llama-omni-server（HTTP，:22500）
+CUDA_VISIBLE_DEVICES=0 /path/to/llama.cpp-omni/build/bin/llama-omni-server \
+    -m "$MODEL" --host 127.0.0.1 --port 22500 -c 8192 -ngl 99 &
+
+# 3) 启动 worker（remote backend 模式，指向后端）
+CUDA_VISIBLE_DEVICES=0 PYTHONPATH=. python worker.py \
+    --host 0.0.0.0 --port 22400 --gpu-id 0 \
+    --backend-server-url http://127.0.0.1:22500 &
+
+# 4) 启动 gateway（本地调试可用 --http；浏览器摄像头/麦克风需改回默认 HTTPS）
+python gateway.py --host 0.0.0.0 --port 8006 --http --workers localhost:22400 &
+
+# 5) 验证
+curl http://127.0.0.1:22500/health   # 后端: {"engine":"comni","status":"ok"}
+curl http://127.0.0.1:22400/health   # worker: {"status":"healthy","worker_status":"idle",...}
+curl http://127.0.0.1:8006/health    # gateway: {"status":"healthy",...}
+# 浏览器打开 http://<host>:8006/
+```
+
+注意事项：
+- 后端需为普通 HTTP 版（`-DLLAMA_OPENSSL=OFF`）。这也解释了官方 Docker 镜像为何不安装 `libssl-dev`——正是为了让 `llama-omni-server` 编为 HTTP 版。
+- **端口冲突**：worker、后端、gateway 默认端口（22400 / 22500 / 8006）在共享机器上可能冲突；被占用时进程会静默退出，请改用空闲端口。
+- **摄像头/麦克风需 HTTPS**：gateway 用 `--http` 时浏览器会禁用媒体设备、只能文本输入；正式使用去掉 `--http`（默认 HTTPS，需 `certs/cert.pem`、`certs/key.pem`）。
+- worker 在 C++ 后端模式下不加载 PyTorch 模型，只把 `session.init / input.append` 透传给后端；对外 WS 路由为 `/v1/worker/chat`（turn_based）与 `/v1/worker/duplex`（full_duplex）。
+
+更多细节参见 Demo 仓库的 `README.md` / `README_zh.md`（`main` 分支）及 `docker-compose.cpp.yml`、`docker/entrypoint-cpp-worker-backend.sh`。
+
+---
+
+## 参考链接
+
+- 本仓库上游：<https://github.com/tc-mb/llama.cpp-omni>
+- 模型（PyTorch）：<https://huggingface.co/openbmb/MiniCPM-o-4_5>
+- 模型（GGUF）：<https://huggingface.co/openbmb/MiniCPM-o-4_5-gguf> · <https://modelscope.cn/models/OpenBMB/MiniCPM-o-4_5-gguf>
+- 在线 Demo：<https://minicpmo45.modelbest.cn/>
+- Demo 仓库：<https://github.com/OpenBMB/MiniCPM-o-Demo>（`main` 分支）
+- HF Space：<https://huggingface.co/spaces/openbmb/MiniCPM-o-4_5-Demo>


### PR DESCRIPTION
## Summary
- Add MiniCPM-o 4.5 · llama.cpp-omni usage guide in both Chinese (`minicpmo_4_5_llamacpp_omni_zh.md`) and English (`minicpmo_4_5_llamacpp_omni.md`).
- Covers the CLI, test programs, Omni server, and the accompanying Demo (online + local deployment).